### PR TITLE
feat: keep only used binaries and extend them to mainnet

### DIFF
--- a/.github/workflows/build_binaries.json
+++ b/.github/workflows/build_binaries.json
@@ -1,12 +1,12 @@
 [
-  {
-    "name": "cuda-linux-x86_64",
-    "runs-on": "ubuntu-22.04",
-    "rust": "nightly-2024-07-07",
-    "target": "x86_64-unknown-linux-gnu",
-    "cross": false,
-    "features": "nvidia"
-  },
+  // {
+  //   "name": "cuda-linux-x86_64",
+  //   "runs-on": "ubuntu-22.04",
+  //   "rust": "nightly-2024-07-07",
+  //   "target": "x86_64-unknown-linux-gnu",
+  //   "cross": false,
+  //   "features": "nvidia"
+  // },
   {
     "name": "opencl-linux-x86_64",
     "runs-on": "ubuntu-22.04",
@@ -15,16 +15,16 @@
     "cross": false,
     "features": "opencl"
   },
-  {
-    "name": "cuda-linux-arm64",
-    "runs-on": "ubuntu-24.04-arm",
-    "rust": "nightly-2024-07-07",
-    "target": "aarch64-unknown-linux-gnu",
-    "cross": false,
-    "features": "nvidia",
-    "build_enabled": true,
-    "best_effort": true
-  },
+  // {
+  //   "name": "cuda-linux-arm64",
+  //   "runs-on": "ubuntu-24.04-arm",
+  //   "rust": "nightly-2024-07-07",
+  //   "target": "aarch64-unknown-linux-gnu",
+  //   "cross": false,
+  //   "features": "nvidia",
+  //   "build_enabled": true,
+  //   "best_effort": true
+  // },
   {
     "name": "opencl-linux-arm64",
     "runs-on": "ubuntu-24.04-arm",
@@ -35,16 +35,16 @@
     "build_enabled": true,
     "best_effort": true
   },
-  {
-    "name": "cuda-linux-riscv64",
-    "runs-on": "ubuntu-latest",
-    "rust": "nightly-2024-07-07",
-    "target": "riscv64gc-unknown-linux-gnu",
-    "cross": true,
-    "features": "opencl",
-    "build_enabled": false,
-    "best_effort": true
-  },
+  // {
+  //   "name": "cuda-linux-riscv64",
+  //   "runs-on": "ubuntu-latest",
+  //   "rust": "nightly-2024-07-07",
+  //   "target": "riscv64gc-unknown-linux-gnu",
+  //   "cross": true,
+  //   "features": "opencl",
+  //   "build_enabled": false,
+  //   "best_effort": true
+  // },
   {
     "name": "opencl-linux-riscv64",
     "runs-on": "ubuntu-latest",
@@ -55,34 +55,34 @@
     "build_enabled": true,
     "best_effort": true
   },
-  {
-    "name": "combined-linux-x86_64",
-    "runs-on": "ubuntu-22.04",
-    "rust": "nightly-2024-07-07",
-    "target": "x86_64-unknown-linux-gnu",
-    "cross": false,
-    "features": "nvidia,opencl"
-  },
-  {
-    "name": "combined-linux-arm64",
-    "runs-on": "ubuntu-24.04-arm",
-    "rust": "nightly-2024-07-07",
-    "target": "aarch64-unknown-linux-gnu",
-    "cross": false,
-    "features": "nvidia,opencl",
-    "build_enabled": true,
-    "best_effort": true
-  },
-  {
-    "name": "combined-linux-riscv64",
-    "runs-on": "ubuntu-latest",
-    "rust": "nightly-2024-07-07",
-    "target": "riscv64gc-unknown-linux-gnu",
-    "cross": false,
-    "features": "nvidia,opencl",
-    "build_enabled": false,
-    "best_effort": true
-  },
+  // {
+  //   "name": "combined-linux-x86_64",
+  //   "runs-on": "ubuntu-22.04",
+  //   "rust": "nightly-2024-07-07",
+  //   "target": "x86_64-unknown-linux-gnu",
+  //   "cross": false,
+  //   "features": "nvidia,opencl"
+  // },
+  // {
+  //   "name": "combined-linux-arm64",
+  //   "runs-on": "ubuntu-24.04-arm",
+  //   "rust": "nightly-2024-07-07",
+  //   "target": "aarch64-unknown-linux-gnu",
+  //   "cross": false,
+  //   "features": "nvidia,opencl",
+  //   "build_enabled": true,
+  //   "best_effort": true
+  // },
+  // {
+  //   "name": "combined-linux-riscv64",
+  //   "runs-on": "ubuntu-latest",
+  //   "rust": "nightly-2024-07-07",
+  //   "target": "riscv64gc-unknown-linux-gnu",
+  //   "cross": false,
+  //   "features": "nvidia,opencl",
+  //   "build_enabled": false,
+  //   "best_effort": true
+  // },
   {
     "name": "opencl-macos-x86_64",
     "runs-on": "macos-13",
@@ -91,14 +91,14 @@
     "cross": false,
     "features": "opencl"
   },
-  {
-    "name": "metal-macos-arm64",
-    "runs-on": "macos-14",
-    "rust": "stable",
-    "target": "aarch64-apple-darwin",
-    "cross": false,
-    "features": "metal"
-  },
+  // {
+  //   "name": "metal-macos-arm64",
+  //   "runs-on": "macos-14",
+  //   "rust": "stable",
+  //   "target": "aarch64-apple-darwin",
+  //   "cross": false,
+  //   "features": "metal"
+  // },
   {
     "name": "combined-macos-arm64",
     "runs-on": "macos-14",
@@ -115,14 +115,14 @@
     "cross": false,
     "features": "opencl"
   },
-  {
-    "name": "cuda-windows-x64",
-    "runs-on": "windows-2019",
-    "rust": "stable",
-    "target": "x86_64-pc-windows-msvc",
-    "cross": false,
-    "features": "nvidia"
-  },
+  // {
+  //   "name": "cuda-windows-x64",
+  //   "runs-on": "windows-2019",
+  //   "rust": "stable",
+  //   "target": "x86_64-pc-windows-msvc",
+  //   "cross": false,
+  //   "features": "nvidia"
+  // },
   {
     "name": "opencl-windows-x64",
     "runs-on": "windows-2019",
@@ -132,16 +132,16 @@
     "cross": false,
     "features": "opencl"
   },
-  {
-    "name": "cuda-windows-arm64",
-    "runs-on": "windows-latest",
-    "rust": "stable",
-    "target": "aarch64-pc-windows-msvc",
-    "cross": false,
-    "features": "nvidia",
-    "build_enabled": true,
-    "best_effort": true
-  },
+  // {
+  //   "name": "cuda-windows-arm64",
+  //   "runs-on": "windows-latest",
+  //   "rust": "stable",
+  //   "target": "aarch64-pc-windows-msvc",
+  //   "cross": false,
+  //   "features": "nvidia",
+  //   "build_enabled": true,
+  //   "best_effort": true
+  // },
   {
     "name": "opencl-windows-arm64",
     "runs-on": "windows-latest",
@@ -153,24 +153,24 @@
     "build_enabled": true,
     "best_effort": true
   },
-  {
-    "name": "combined-windows-x64",
-    "runs-on": "windows-2019",
-    "rust": "stable",
-    "target": "x86_64-pc-windows-msvc",
-    "rustflags": "-L C:/vcpkg/packages/opencl_x64-windows/lib",
-    "cross": false,
-    "features": "opencl,nvidia"
-  },
-  {
-    "name": "combined-windows-arm64",
-    "runs-on": "windows-latest",
-    "rust": "stable",
-    "target": "aarch64-pc-windows-msvc",
-    "rustflags": "-L C:/vcpkg/packages/opencl_x64-windows/lib",
-    "cross": false,
-    "features": "opencl,nvidia",
-    "build_enabled": false,
-    "best_effort": true
-  }
+  // {
+  //   "name": "combined-windows-x64",
+  //   "runs-on": "windows-2019",
+  //   "rust": "stable",
+  //   "target": "x86_64-pc-windows-msvc",
+  //   "rustflags": "-L C:/vcpkg/packages/opencl_x64-windows/lib",
+  //   "cross": false,
+  //   "features": "opencl,nvidia"
+  // },
+  // {
+  //   "name": "combined-windows-arm64",
+  //   "runs-on": "windows-latest",
+  //   "rust": "stable",
+  //   "target": "aarch64-pc-windows-msvc",
+  //   "rustflags": "-L C:/vcpkg/packages/opencl_x64-windows/lib",
+  //   "cross": false,
+  //   "features": "opencl,nvidia",
+  //   "build_enabled": false,
+  //   "best_effort": true
+  // }
 ]

--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -66,6 +66,7 @@ jobs:
           AinputJQ=(
             '{"tari_network": "esme","tari_target_network": "testnet"}'
             '{"tari_network": "nextnet","tari_target_network": "nextnet"}'
+            '{"tari_network": "mainnet","tari_target_network": "mainnet"}'
           )
           echo ${AinputJQ[@]}
           echo ${matrix_selection} | jq -s -c > matrix-temp.json

--- a/src/metal_engine.rs
+++ b/src/metal_engine.rs
@@ -85,13 +85,12 @@ impl EngineImpl for MetalEngine {
         Ok(Device::all().len() as u32)
     }
 
-
-    fn create_kernel(&self, function: &Self::Function) -> Result<Self::Kernel, anyhow::Error>{
+    fn create_kernel(&self, function: &Self::Function) -> Result<Self::Kernel, anyhow::Error> {
         let kernel = function
-        .program
-        .get_function("sha3", None)
-        .map_err(|error| anyhow::anyhow!("Failed to get function sha3: {:?}", error))?;
-        Ok(MetalKernel{ kernel })
+            .program
+            .get_function("sha3", None)
+            .map_err(|error| anyhow::anyhow!("Failed to get function sha3: {:?}", error))?;
+        Ok(MetalKernel { kernel })
     }
 
     fn detect_devices(&self) -> Result<Vec<GpuDevice>, anyhow::Error> {
@@ -155,7 +154,6 @@ impl EngineImpl for MetalEngine {
         Ok(MetalFunction { program: function })
     }
 
-
     fn mine(
         &self,
         kernel: &Self::Kernel,
@@ -167,8 +165,7 @@ impl EngineImpl for MetalEngine {
         num_iterations: u32,
         block_size: u32,
         grid_size: u32,
-    ) -> Result<(Option<u64>, u32, u64), anyhow::Error>
-{
+    ) -> Result<(Option<u64>, u32, u64), anyhow::Error> {
         autoreleasepool(|| {
             let command_queue = context.context.new_command_queue();
 
@@ -177,8 +174,6 @@ impl EngineImpl for MetalEngine {
 
             let command_buffer = command_queue.new_command_buffer();
             let encoder = command_buffer.new_compute_command_encoder();
-
-           
 
             let pipeline_state = create_pipeline_state(&context.context, &kernel.kernel)?;
             encoder.set_compute_pipeline_state(&pipeline_state);
@@ -336,6 +331,5 @@ fn create_program_from_source(context: &Device) -> Result<Library, anyhow::Error
 }
 
 pub struct MetalKernel {
-    kernel: Function
+    kernel: Function,
 }
-


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Disabled CUDA-only and combined (NVIDIA + OpenCL) build configurations in the build process; OpenCL-only builds remain active.
  - Expanded build coverage by adding support for the "mainnet" network in the build matrix, alongside existing test networks.
  - Applied minor formatting improvements to enhance code readability without affecting functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->