### PR TITLE
chore(ci): fix cargo install with locked build command

### DIFF
--- a/.github/workflows/build_binaries.json
+++ b/.github/workflows/build_binaries.json
@@ -1,12 +1,13 @@
 [
-  // {
-  //   "name": "cuda-linux-x86_64",
-  //   "runs-on": "ubuntu-22.04",
-  //   "rust": "nightly-2024-07-07",
-  //   "target": "x86_64-unknown-linux-gnu",
-  //   "cross": false,
-  //   "features": "nvidia"
-  // },
+  {
+    "name": "cuda-linux-x86_64",
+    "runs-on": "ubuntu-22.04",
+    "rust": "nightly-2024-07-07",
+    "target": "x86_64-unknown-linux-gnu",
+    "cross": false,
+    "features": "nvidia",
+    "build_enabled": false
+  },
   {
     "name": "opencl-linux-x86_64",
     "runs-on": "ubuntu-22.04",
@@ -15,16 +16,16 @@
     "cross": false,
     "features": "opencl"
   },
-  // {
-  //   "name": "cuda-linux-arm64",
-  //   "runs-on": "ubuntu-24.04-arm",
-  //   "rust": "nightly-2024-07-07",
-  //   "target": "aarch64-unknown-linux-gnu",
-  //   "cross": false,
-  //   "features": "nvidia",
-  //   "build_enabled": true,
-  //   "best_effort": true
-  // },
+  {
+    "name": "cuda-linux-arm64",
+    "runs-on": "ubuntu-24.04-arm",
+    "rust": "nightly-2024-07-07",
+    "target": "aarch64-unknown-linux-gnu",
+    "cross": false,
+    "features": "nvidia",
+    "build_enabled": false,
+    "best_effort": true
+  },
   {
     "name": "opencl-linux-arm64",
     "runs-on": "ubuntu-24.04-arm",
@@ -35,16 +36,16 @@
     "build_enabled": true,
     "best_effort": true
   },
-  // {
-  //   "name": "cuda-linux-riscv64",
-  //   "runs-on": "ubuntu-latest",
-  //   "rust": "nightly-2024-07-07",
-  //   "target": "riscv64gc-unknown-linux-gnu",
-  //   "cross": true,
-  //   "features": "opencl",
-  //   "build_enabled": false,
-  //   "best_effort": true
-  // },
+  {
+    "name": "cuda-linux-riscv64",
+    "runs-on": "ubuntu-latest",
+    "rust": "nightly-2024-07-07",
+    "target": "riscv64gc-unknown-linux-gnu",
+    "cross": true,
+    "features": "opencl",
+    "build_enabled": false,
+    "best_effort": true
+  },
   {
     "name": "opencl-linux-riscv64",
     "runs-on": "ubuntu-latest",
@@ -55,34 +56,35 @@
     "build_enabled": true,
     "best_effort": true
   },
-  // {
-  //   "name": "combined-linux-x86_64",
-  //   "runs-on": "ubuntu-22.04",
-  //   "rust": "nightly-2024-07-07",
-  //   "target": "x86_64-unknown-linux-gnu",
-  //   "cross": false,
-  //   "features": "nvidia,opencl"
-  // },
-  // {
-  //   "name": "combined-linux-arm64",
-  //   "runs-on": "ubuntu-24.04-arm",
-  //   "rust": "nightly-2024-07-07",
-  //   "target": "aarch64-unknown-linux-gnu",
-  //   "cross": false,
-  //   "features": "nvidia,opencl",
-  //   "build_enabled": true,
-  //   "best_effort": true
-  // },
-  // {
-  //   "name": "combined-linux-riscv64",
-  //   "runs-on": "ubuntu-latest",
-  //   "rust": "nightly-2024-07-07",
-  //   "target": "riscv64gc-unknown-linux-gnu",
-  //   "cross": false,
-  //   "features": "nvidia,opencl",
-  //   "build_enabled": false,
-  //   "best_effort": true
-  // },
+  {
+    "name": "combined-linux-x86_64",
+    "runs-on": "ubuntu-22.04",
+    "rust": "nightly-2024-07-07",
+    "target": "x86_64-unknown-linux-gnu",
+    "cross": false,
+    "features": "nvidia,opencl",
+    "build_enabled": false
+  },
+  {
+    "name": "combined-linux-arm64",
+    "runs-on": "ubuntu-24.04-arm",
+    "rust": "nightly-2024-07-07",
+    "target": "aarch64-unknown-linux-gnu",
+    "cross": false,
+    "features": "nvidia,opencl",
+    "build_enabled": false,
+    "best_effort": true
+  },
+  {
+    "name": "combined-linux-riscv64",
+    "runs-on": "ubuntu-latest",
+    "rust": "nightly-2024-07-07",
+    "target": "riscv64gc-unknown-linux-gnu",
+    "cross": false,
+    "features": "nvidia,opencl",
+    "build_enabled": false,
+    "best_effort": true
+  },
   {
     "name": "opencl-macos-x86_64",
     "runs-on": "macos-13",
@@ -91,14 +93,15 @@
     "cross": false,
     "features": "opencl"
   },
-  // {
-  //   "name": "metal-macos-arm64",
-  //   "runs-on": "macos-14",
-  //   "rust": "stable",
-  //   "target": "aarch64-apple-darwin",
-  //   "cross": false,
-  //   "features": "metal"
-  // },
+  {
+    "name": "metal-macos-arm64",
+    "runs-on": "macos-14",
+    "rust": "stable",
+    "target": "aarch64-apple-darwin",
+    "cross": false,
+    "features": "metal",
+    "build_enabled": false
+  },
   {
     "name": "combined-macos-arm64",
     "runs-on": "macos-14",
@@ -115,14 +118,15 @@
     "cross": false,
     "features": "opencl"
   },
-  // {
-  //   "name": "cuda-windows-x64",
-  //   "runs-on": "windows-2019",
-  //   "rust": "stable",
-  //   "target": "x86_64-pc-windows-msvc",
-  //   "cross": false,
-  //   "features": "nvidia"
-  // },
+  {
+    "name": "cuda-windows-x64",
+    "runs-on": "windows-2019",
+    "rust": "stable",
+    "target": "x86_64-pc-windows-msvc",
+    "cross": false,
+    "features": "nvidia",
+    "build_enabled": false
+  },
   {
     "name": "opencl-windows-x64",
     "runs-on": "windows-2019",
@@ -132,16 +136,16 @@
     "cross": false,
     "features": "opencl"
   },
-  // {
-  //   "name": "cuda-windows-arm64",
-  //   "runs-on": "windows-latest",
-  //   "rust": "stable",
-  //   "target": "aarch64-pc-windows-msvc",
-  //   "cross": false,
-  //   "features": "nvidia",
-  //   "build_enabled": true,
-  //   "best_effort": true
-  // },
+  {
+    "name": "cuda-windows-arm64",
+    "runs-on": "windows-latest",
+    "rust": "stable",
+    "target": "aarch64-pc-windows-msvc",
+    "cross": false,
+    "features": "nvidia",
+    "build_enabled": false,
+    "best_effort": true
+  },
   {
     "name": "opencl-windows-arm64",
     "runs-on": "windows-latest",
@@ -153,24 +157,25 @@
     "build_enabled": true,
     "best_effort": true
   },
-  // {
-  //   "name": "combined-windows-x64",
-  //   "runs-on": "windows-2019",
-  //   "rust": "stable",
-  //   "target": "x86_64-pc-windows-msvc",
-  //   "rustflags": "-L C:/vcpkg/packages/opencl_x64-windows/lib",
-  //   "cross": false,
-  //   "features": "opencl,nvidia"
-  // },
-  // {
-  //   "name": "combined-windows-arm64",
-  //   "runs-on": "windows-latest",
-  //   "rust": "stable",
-  //   "target": "aarch64-pc-windows-msvc",
-  //   "rustflags": "-L C:/vcpkg/packages/opencl_x64-windows/lib",
-  //   "cross": false,
-  //   "features": "opencl,nvidia",
-  //   "build_enabled": false,
-  //   "best_effort": true
-  // }
+  {
+    "name": "combined-windows-x64",
+    "runs-on": "windows-2019",
+    "rust": "stable",
+    "target": "x86_64-pc-windows-msvc",
+    "rustflags": "-L C:/vcpkg/packages/opencl_x64-windows/lib",
+    "cross": false,
+    "features": "opencl,nvidia",
+    "build_enabled": false
+  },
+  {
+    "name": "combined-windows-arm64",
+    "runs-on": "windows-latest",
+    "rust": "stable",
+    "target": "aarch64-pc-windows-msvc",
+    "rustflags": "-L C:/vcpkg/packages/opencl_x64-windows/lib",
+    "cross": false,
+    "features": "opencl,nvidia",
+    "build_enabled": false,
+    "best_effort": true
+  }
 ]

--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -237,7 +237,7 @@ jobs:
         shell: bash
         run: |
           #cargo install cross
-          cargo install cross --git https://github.com/cross-rs/cross
+          cargo install cross --git https://github.com/cross-rs/cross --locked
           echo "CARGO=cross" >> $GITHUB_ENV
           # Disable - [cross] warning: Found conflicting cross configuration
           echo "CROSS_NO_WARNINGS=0" >> $GITHUB_ENV
@@ -246,7 +246,7 @@ jobs:
         if: ${{ ( ! matrix.builds.cross ) }}
         shell: bash
         run: |
-          cargo install cargo-auditable cargo-audit
+          cargo install cargo-auditable cargo-audit --locked
           echo "CARGO=${{ env.CARGO }} auditable" >> $GITHUB_ENV
 
       - name: Build release targets


### PR DESCRIPTION
Description
Fix cargo install with locked build command

Motivation and Context
Fix builds for cargo install cross and audit

How Has This Been Tested?
Builds in local fork.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated build process to use reproducible installation of tools by adding the `--locked` flag to relevant commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->