### PR TITLE
fix: remove dynamic iterations

### DIFF
--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -42,7 +42,7 @@ impl Default for ConfigFile {
             per_device_grid_sizes: vec![],
             template_timeout_secs: 3,
             max_template_failures: 10,
-            iterations_per_cycle: None,
+            iterations_per_cycle: Some(1),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -769,7 +769,7 @@ fn run_thread(
     let mut data = vec![0u64; 6];
     // let mut data_buf = data.as_slice().as_dbuf()?;
 
-    let mut num_iterations = 4;
+    let mut num_iterations = 1;
     if let Some(fixed_num_iterations) = fixed_num_iterations {
         info!(target: LOG_TARGET, "Using fixed num iterations: {}", fixed_num_iterations);
         num_iterations = fixed_num_iterations;
@@ -853,13 +853,13 @@ fn run_thread(
                             * data_buf.as_device_ptr(),
                             * &output_buf, */
             );
-            if fixed_num_iterations.is_none() {
-                if mining_time.elapsed().as_secs() > 1500 {
-                    num_iterations = cmp::max(1, num_iterations - 1);
-                } else if mining_time.elapsed().as_millis() < 1000 {
-                    num_iterations = num_iterations + 1;
-                }
-            }
+            // if fixed_num_iterations.is_none() {
+            //     if mining_time.elapsed().as_secs() > 1500 {
+            //         num_iterations = cmp::max(1, num_iterations - 1);
+            //     } else if mining_time.elapsed().as_millis() < 1000 {
+            //         num_iterations = num_iterations + 1;
+            //     }
+            // }
             let (nonce, hashes, diff) = match result {
                 Ok(values) => {
                     debug!(target: LOG_TARGET,


### PR DESCRIPTION
On my machine at least, this dynamic iterations logic ends up making the machine very unresponsive, at least in tari universe. 

This PR reverts that logic